### PR TITLE
Add  get-user-data script

### DIFF
--- a/etc/rc.d/smartdc
+++ b/etc/rc.d/smartdc
@@ -16,4 +16,5 @@ if [ ! -f /lib/smartdc/.firstboot-complete-do-not-delete ] ; then
   (/lib/smartdc/firstboot)
 fi
 (/lib/smartdc/run-operator-script)
+(/lib/smartdc/get-user-data)
 (/lib/smartdc/run-user-script)

--- a/lib/smartdc/get-user-data
+++ b/lib/smartdc/get-user-data
@@ -1,0 +1,30 @@
+#!/usr/local/bin/bash
+#
+# Copyright (c) 2014 Joyent Inc., All rights reserved.
+#
+# Get metadata user-data (via mdata-get)
+# This script is executed every boot and must be executed
+# before script "run-user-script"
+
+# load common functions and vars
+. /lib/smartdc/lib_smartdc_scripts.cfg
+
+lib_smartdc_info "Retrieving metadata user-data"
+$MDATA_GET_BIN user-data >/var/db/mdata-user-data.new
+case $? in
+  0)
+    lib_smartdc_info "Metadata user-data successfuly retrieved."
+    mv /var/db/mdata-user-data{.new,}
+    lib_smartdc_info "User-data saved to /var/db/mdata-user-data."
+    ;;
+  1)
+    lib_smartdc_info "Metadata user-data not defined."
+    rm -f /var/db/mdata-user-data{,.new}
+    ;;
+  *)
+    lib_smartdc_info "Metadata couldn't be retrieved."
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
This script attempts to retrieve user-data via `mdata-get user-data`.
If the meta-data value exists, it is save to /var/db/mdata-user-data.
Note: this script must be run _before_ run-user-script.
